### PR TITLE
feat: Switch to Non-Attribute Proc Macro

### DIFF
--- a/openapi-gen-core/src/refs.rs
+++ b/openapi-gen-core/src/refs.rs
@@ -25,10 +25,11 @@ pub(crate) trait Refable: Sized + Clone {
     fn regex_string() -> &'static str;
 
     fn name(r: &str) -> Result<&str, String> {
-        let reg: Regex = regex::Regex::new(Self::regex_string()).unwrap();
+        let regex_string = Self::regex_string();
+        let reg: Regex = regex::Regex::new(regex_string).unwrap();
         let m = reg
             .captures(r)
-            .ok_or_else(|| "Reference does not match regex for Schema".to_owned())?;
+            .ok_or_else(|| format!("Reference {r} does not match regex string {}", regex_string))?;
         Ok(m.get(1).unwrap().as_str())
     }
 }

--- a/openapi-gen-core/tests/petstore_snapshot.rs
+++ b/openapi-gen-core/tests/petstore_snapshot.rs
@@ -8,9 +8,7 @@ use utils::*;
 fn test_petstore_snapshot() {
     let args = MacroArgs {
         path: "../fixtures/petstore.json".to_string(),
-    };
-    let input = quote::quote! {
-        mod test {}
+        name: Some("test".to_string()),
     };
 
     let expected = parse_quote! {
@@ -97,5 +95,5 @@ fn test_petstore_snapshot() {
       }
     };
 
-    assert_token_streams_match(api(args, input), expected);
+    assert_token_streams_match(api(args), expected);
 }

--- a/openapi-gen-core/tests/simple_site_snapshot.rs
+++ b/openapi-gen-core/tests/simple_site_snapshot.rs
@@ -8,9 +8,7 @@ use utils::*;
 fn test_simple_site() {
     let args = MacroArgs {
         path: "../fixtures/simple_site.json".to_string(),
-    };
-    let input = quote::quote! {
-        mod test {}
+        name: Some("test".to_string()),
     };
 
     let expected = parse_quote! {
@@ -99,5 +97,5 @@ fn test_simple_site() {
       }
     };
 
-    assert_token_streams_match(api(args, input), expected);
+    assert_token_streams_match(api(args), expected);
 }

--- a/openapi-gen-macro/src/lib.rs
+++ b/openapi-gen-macro/src/lib.rs
@@ -3,11 +3,8 @@ use openapi_gen_core::MacroArgs;
 
 use openapi_gen_core::syn::parse_macro_input;
 
-#[proc_macro_attribute]
-pub fn api(
-    attr_stream: proc_macro::TokenStream,
-    input: proc_macro::TokenStream,
-) -> proc_macro::TokenStream {
+#[proc_macro]
+pub fn api(attr_stream: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let attrs = parse_macro_input!(attr_stream as openapi_gen_core::syn::AttributeArgs);
     let args = match MacroArgs::from_list(&attrs) {
         Ok(v) => v,
@@ -16,5 +13,5 @@ pub fn api(
         }
     };
 
-    openapi_gen_core::api(args, input.into()).into()
+    openapi_gen_core::api(args).into()
 }

--- a/usage-example/src/main.rs
+++ b/usage-example/src/main.rs
@@ -1,10 +1,6 @@
 use openapi_gen_macro::api;
 
-#[api(path = "../fixtures/simple_site.json")]
-mod some_site {}
-
-#[api(path = "../fixtures/petstore.json")]
-mod petstore {}
+api!(path = "../fixtures/simple_site.json", name = "some_site");
 
 fn main() {
     let _ = some_site::test_more::post::request::Body {


### PR DESCRIPTION
This started out as an attribute style proc macro that you were supposed to attach to a module.

But it really made more sense to be a 'standard' proc-macro instead, which generates its own module! This also might have a bit better IDE support but we'll see